### PR TITLE
Fix docs for Image element

### DIFF
--- a/docs/src/Fulma/Elements/Image/View.fs
+++ b/docs/src/Fulma/Elements/Image/View.fs
@@ -27,4 +27,4 @@ let root model dispatch =
                         (Viewer.View.root fixedInteractive model.FixedViewer (FixedViewerMsg >> dispatch))
                      Render.docSection
                         "### Responsive images with ratio"
-                        (Viewer.View.root responsiveInteractive model.FixedViewer (FixedViewerMsg >> dispatch)) ]
+                        (Viewer.View.root responsiveInteractive model.ResponsiveViewer (ResponsiveViewerMsg >> dispatch)) ]


### PR DESCRIPTION
The [docs for `Image`](https://mangelmaxime.github.io/Fulma/#fulma/elements/image) currently show the wrong code for the "Responsive images with ratio" section. This should fix it.