### PR TITLE
allow Extensions.PageLoader to have children

### DIFF
--- a/src/Fulma.Extensions/PageLoader.fs
+++ b/src/Fulma.Extensions/PageLoader.fs
@@ -70,4 +70,4 @@ module PageLoader =
                     [ opts.CustomClass.Value, opts.CustomClass.IsSome
                       Classes.IsActive , opts.IsActive ] :> IHTMLProp
               yield! opts.Props ]
-            [ ]
+            children


### PR DESCRIPTION
Children were not being passed to the PageLoader's div.

Docs show content inside the pageloader div, useful for loading messages and such. https://wikiki.github.io/bulma-extensions/pageloader