### PR TITLE
Remove pointfree style

### DIFF
--- a/src/Fulma/Elements/Heading.fs
+++ b/src/Fulma/Elements/Heading.fs
@@ -89,4 +89,4 @@ module Heading =
     let h4 (options : Option list) = title h4 (is4 :: options)
     let h5 (options : Option list) = title h5 (is5 :: options)
     let h6 (options : Option list) = title h6 (is6 :: options)
-    let p = title p
+    let p opts children = title p opts children


### PR DESCRIPTION
Fable 1.3.3 gives you warnings for functions declared with point-free style. I got this one for Fulma :)