### PR TITLE
Table's "is-stripped" css class should be "is-striped"

### DIFF
--- a/docs/src/Fulma/Elements/Table.fs
+++ b/docs/src/Fulma/Elements/Table.fs
@@ -31,7 +31,7 @@ let simpleInteractive () =
 let modifierInteractive () =
     Table.table [ Table.IsBordered
                   Table.IsNarrow
-                  Table.IsStripped ]
+                  Table.IsStriped ]
         [ thead [ ]
             [ tr [ ]
                  [ th [ ] [ str "Firstname" ]
@@ -54,7 +54,7 @@ let modifierInteractive () =
 let modifierFullWitdth () =
     Table.table [ Table.IsBordered
                   Table.IsFullwidth
-                  Table.IsStripped ]
+                  Table.IsStriped ]
         [ thead [ ]
             [ tr [ ]
                  [ th [ ] [ str "Firstname" ]
@@ -90,7 +90,7 @@ let view =
 
 There are four modifiers:
 - `Table.IsBordered`
-- `Table.IsStripped`
+- `Table.IsStriped`
 
 and 2 options for table spacing:
 - `Table.IsNarrow`

--- a/src/Fulma/Elements/Table.fs
+++ b/src/Fulma/Elements/Table.fs
@@ -14,7 +14,7 @@ module Table =
                 let [<Literal>] IsSelected = "is-selected"
         module Style =
           let [<Literal>] IsBordered = "is-bordered"
-          let [<Literal>] IsStripped = "is-stripped "
+          let [<Literal>] IsStriped = "is-striped"
           let [<Literal>] IsFullwidth = "is-fullwidth"
           let [<Literal>] IsHoverable = "is-hoverable"
         module Spacing =
@@ -24,7 +24,7 @@ module Table =
         /// Set `is-hovered` class
         | IsBordered
         /// Set `is-stripped` class
-        | IsStripped
+        | IsStriped
         /// Set `is-fullwidth` class
         | IsFullwidth
         /// Set `is-narrow` class
@@ -36,7 +36,7 @@ module Table =
 
     type private TableOptions =
         { IsBordered : bool
-          IsStripped : bool
+          IsStriped : bool
           IsFullwidth : bool
           IsNarrow : bool
           IsHoverable : bool
@@ -44,7 +44,7 @@ module Table =
           Props : IHTMLProp list }
         static member Empty =
             { IsBordered = false
-              IsStripped = false
+              IsStriped = false
               IsNarrow = false
               IsFullwidth = false
               IsHoverable = false
@@ -56,7 +56,7 @@ module Table =
         let parseOptions (result : TableOptions) =
             function
             | IsBordered -> { result with IsBordered = true }
-            | IsStripped -> { result with IsStripped = true }
+            | IsStriped -> { result with IsStriped = true }
             | IsFullwidth -> { result with IsFullwidth = true }
             | IsNarrow -> { result with IsNarrow = true }
             | IsHoverable -> { result with IsHoverable = true }
@@ -66,7 +66,7 @@ module Table =
         let opts = options |> List.fold parseOptions TableOptions.Empty
         let classes = Helpers.classes Classes.Container [opts.CustomClass]
                         [ Classes.Style.IsBordered, opts.IsBordered
-                          Classes.Style.IsStripped, opts.IsStripped
+                          Classes.Style.IsStriped, opts.IsStriped
                           Classes.Style.IsFullwidth, opts.IsFullwidth
                           Classes.Spacing.IsNarrow, opts.IsNarrow
                           Classes.Style.IsHoverable, opts.IsHoverable ]


### PR DESCRIPTION
Also renamed "IsStripped" to "IsStriped" everywhere in the code to match the css class name.
Note: this is a breaking change, but I guess it's better this way...