### PR TITLE
Typo in comments

### DIFF
--- a/src/Fulma/Layouts/Tile.fs
+++ b/src/Fulma/Layouts/Tile.fs
@@ -87,7 +87,7 @@ module Tile =
               Props = []
               Context = None }
 
-    /// Generate <div class="title"></div>
+    /// Generate <div class="tile"></div>
     let tile (options: Option list) children =
         let parseOptions (result: Options) =
             function
@@ -108,14 +108,14 @@ module Tile =
               yield! opts.Props ]
             children
 
-    /// Generate <div class="title is-parent"></div>
+    /// Generate <div class="tile is-parent"></div>
     let parent (options: Option list) children =
         tile (IsParent :: options) children
 
-    /// Generate <div class="title is-child"></div>
+    /// Generate <div class="tile is-child"></div>
     let child (options: Option list) children =
         tile (IsChild :: options) children
 
-    /// Generate <div class="title is-ancestor"></div>
+    /// Generate <div class="tile is-ancestor"></div>
     let ancestor (options: Option list) children =
         tile (IsAncestor :: options) children


### PR DESCRIPTION
Css class in generated markup is `"tile..."` not `"title..."`