### PR TITLE
Field and Control are missing is-expanded class

### DIFF
--- a/docs/src/Fulma/Elements/Form.fs
+++ b/docs/src/Fulma/Elements/Form.fs
@@ -37,7 +37,15 @@ let basic () =
                       Icon.faIcon [ Icon.Size IsSmall; Icon.IsRight ] [ Fa.icon Fa.I.Warning ] ]
                   Help.help [ Help.Color IsDanger ]
                     [ str "This email is invalid" ] ]
-           // Subject field
+           // Phone field
+           Field.div [ ]
+                [ Field.div [ Field.HasAddons ]
+                    [ Control.p [ ]
+                        [ Button.button [ Button.IsStatic true ]
+                            [ str "+32" ] ]
+                      Control.p [ Control.IsExpanded ]
+                        [ Input.tel [ Input.Placeholder "expanded phone number field" ] ] ] ]
+            // Subject field
            Field.div [ ]
                 [ Label.label [ ]
                     [ str "Subject" ]

--- a/src/Fulma/Elements/Form/Control.fs
+++ b/src/Fulma/Elements/Form/Control.fs
@@ -51,7 +51,7 @@ module Control =
             | CustomClass customClass -> { result with CustomClass = customClass |> Some }
             | Props props -> { result with Props = props }
             | IsLoading state -> { result with IsLoading = state }
-            | IsExpanded  -> { result with IsExpanded = state }
+            | IsExpanded  -> { result with IsExpanded = true }
 
         let opts = options |> List.fold parseOptions Options.Empty
 

--- a/src/Fulma/Elements/Form/Control.fs
+++ b/src/Fulma/Elements/Form/Control.fs
@@ -22,6 +22,8 @@ module Control =
         | HasIconLeft
         /// Add `is-loading` class if true
         | IsLoading of bool
+        /// Add `is-expanded` class
+        | IsExpanded
         | CustomClass of string
         | Props of IHTMLProp list
 

--- a/src/Fulma/Elements/Form/Control.fs
+++ b/src/Fulma/Elements/Form/Control.fs
@@ -14,6 +14,7 @@ module Control =
             let [<Literal>] Right = "has-icons-right"
         module State =
             let [<Literal>] IsLoading = "is-loading"
+        let [<Literal>] IsExpanded = "is-expanded"
 
     type Option =
         /// Add `has-icon-right` class
@@ -32,13 +33,15 @@ module Control =
           HasIconRight : bool
           CustomClass : string option
           Props : IHTMLProp list
-          IsLoading : bool }
+          IsLoading : bool
+          IsExpanded : bool }
         static member Empty =
             { HasIconLeft = false
               HasIconRight = false
               CustomClass = None
               Props = []
-              IsLoading = false }
+              IsLoading = false
+              IsExpanded = false }
 
     let internal controlView element options children =
         let parseOptions (result : Options) =
@@ -48,6 +51,7 @@ module Control =
             | CustomClass customClass -> { result with CustomClass = customClass |> Some }
             | Props props -> { result with Props = props }
             | IsLoading state -> { result with IsLoading = state }
+            | IsExpanded  -> { result with IsExpanded = state }
 
         let opts = options |> List.fold parseOptions Options.Empty
 
@@ -56,7 +60,8 @@ module Control =
                         [ opts.CustomClass ]
                         [ Classes.State.IsLoading, opts.IsLoading
                           Classes.HasIcon.Right, opts.HasIconRight
-                          Classes.HasIcon.Left, opts.HasIconLeft ]
+                          Classes.HasIcon.Left, opts.HasIconLeft
+                          Classes.IsExpanded, opts.IsExpanded ]
 
         element (classes::opts.Props)
             children


### PR DESCRIPTION
Concerning: #126 

Added:
- IsExpanded to Control
- Example in https://mangelmaxime.github.io/Fulma/#fulma/elements/form
![image](https://user-images.githubusercontent.com/2250570/39329765-b121cb34-499f-11e8-8e47-c61d41f7a954.png)
