### PR TITLE
[WIP]  Delete current date from the DatePicker when delete or backspace is pressed

### DIFF
--- a/docs/src/FulmaElmish/DatePicker.fs
+++ b/docs/src/FulmaElmish/DatePicker.fs
@@ -30,7 +30,8 @@ type DatePickerDemo(props) =
                                                  // See #56: https://github.com/MangelMaxime/Fulma/issues/56#issuecomment-332186559
                                                  ZIndex 10. ] }
 
-    do base.setInitState({ DatePickerState = { DatePicker.Types.defaultState with AutoClose = true }
+    do base.setInitState({ DatePickerState = { DatePicker.Types.defaultState with AutoClose = true
+                                                                                  ShowDeleteButton = true }
                            CurrentDate = None })
 
     member this.datePickerChanged (newState, newDate) =
@@ -88,7 +89,8 @@ type Msg =
 *Update.fs*
 ```fs
 let init() =
-    { DatePickerState = { DatePicker.Types.defaultState with AutoClose = true }
+    { DatePickerState = { DatePicker.Types.defaultState with AutoClose = true
+                                                             ShowDeleteButton = true }
       CurrentDate = None }
 
 let update msg model =

--- a/src/Fulma.Elmish/DatePicker/Types.fs
+++ b/src/Fulma.Elmish/DatePicker/Types.fs
@@ -12,7 +12,8 @@ module Types =
           ReferenceDate : DateTime
           AutoClose : bool
           ForceClose : bool
-          TitleFormat : string }
+          TitleFormat : string
+          ShowDeleteButton : bool  }
 
     let defaultState =
         { Today = None
@@ -20,7 +21,8 @@ module Types =
           ReferenceDate = DateTime.UtcNow
           AutoClose = false
           ForceClose = false
-          TitleFormat = "" }
+          TitleFormat = ""
+          ShowDeleteButton = false  }
 
     type Config<'Msg> =
         { OnChange : State * (DateTime option) -> 'Msg

--- a/src/Fulma.Elmish/DatePicker/View.fs
+++ b/src/Fulma.Elmish/DatePicker/View.fs
@@ -103,7 +103,7 @@ module View =
             [
               yield Field.body [] [
                   Field.div (if state.ShowDeleteButton then [Field.HasAddons] else []) [
-                    yield Control.p [] [
+                    yield Control.p [ Control.IsExpanded ] [
                             Input.text [ Input.Props [ Value dateTxt
                                                        OnFocus (fun _ -> onFocus config state currentDate dispatch)
                                                        OnClick (fun _ -> onFocus config state currentDate dispatch)

--- a/src/Fulma.Elmish/DatePicker/View.fs
+++ b/src/Fulma.Elmish/DatePicker/View.fs
@@ -28,6 +28,9 @@ module View =
             (state, currentDate)
             |> dispatch
 
+    let onDeleteClick (config : Config<'Msg>) state (currentDate : DateTime option) dispatch =
+        if currentDate.IsSome then config.OnChange (state, None) |> dispatch
+
     let calendar (config : Config<'Msg>) state (currentDate : DateTime option) dispatch =
         let isCurrentMonth (date : DateTime) =
             state.ReferenceDate.Month  = date.Month
@@ -97,11 +100,23 @@ module View =
                 Date.Format.localFormat config.Local config.Local.Date.DefaultFormat date
             | None -> ""
         div [ ]
-            [ yield Input.text [ Input.Props [ Value dateTxt
-                                               OnFocus (fun _ -> onFocus config state currentDate dispatch)
-                                               OnClick (fun _ -> onFocus config state currentDate dispatch)
-                                               // TODO: Implement something to trigger onChange only if the value actually change
-                                               OnBlur (fun _ -> let newState = { state with InputFocused = false }
-                                                                onChange config newState currentDate dispatch) ] ]
+            [
+              yield Field.body [] [
+                  Field.div (if state.ShowDeleteButton then [Field.HasAddons] else []) [
+                    yield Control.p [] [
+                            Input.text [ Input.Props [ Value dateTxt
+                                                       OnFocus (fun _ -> onFocus config state currentDate dispatch)
+                                                       OnClick (fun _ -> onFocus config state currentDate dispatch)
+                                                       // TODO: Implement something to trigger onChange only if the value actually change
+                                                       OnBlur (fun _ -> let newState = { state with InputFocused = false }
+                                                                        onChange config newState currentDate dispatch) ]; ] ]
+
+                    if state.ShowDeleteButton then
+                        yield Control.p [] [
+                                Button.a [ Button.OnClick(fun _ -> onDeleteClick config state currentDate dispatch) ]
+                                    [ Icon.faIcon [] [ Fa.icon Fa.I.Times ] ] ]
+                  ]
+              ]
+
               if isCalendarDisplayed state then
                 yield calendar config state currentDate dispatch ]


### PR DESCRIPTION
Currently it's not possible to delete the current date once one was selected, at least I haven't found a way :)

I've implemented a simple way to delete the current date by pressing either the delete or backspace button
![2018-06-04_17-10-13](https://user-images.githubusercontent.com/6583600/40926425-73be251c-681c-11e8-8362-bc8f7cc86490.gif)

While this works and is good enough for a POC, it's not very intuitive from a users POV, hence why it's marked as WIP. 
So I would like to know if the DatePicker should include this feature and if so, what you would like to see in the final version. I've tried to add a image to the input but haven't figured out how I can handle `OnClick` on the `span` from the image. 

Regards