### PR TITLE
Remove unnecessary upcast in divider

### DIFF
--- a/src/Fulma.Extensions/Divider.fs
+++ b/src/Fulma.Extensions/Divider.fs
@@ -43,6 +43,6 @@ module Divider =
         let classes = Helpers.classes "" [opts.CustomClass] [Classes.Divider, not opts.IsVertical; Classes.IsVertical, opts.IsVertical]
         let attrs =
             match opts.Label with
-            | Some label -> classes:: (Data("content", label) :> IHTMLProp)::opts.Props
+            | Some label -> classes:: Data("content", label)::opts.Props
             | None -> classes::opts.Props
         div attrs [ ]


### PR DESCRIPTION
This PR gets rid of the following compilation warning when using a `Divider` in `Fulma.Extensions`:

> WARNING in C:/Users/egger/.nuget/packages/fulma.extensions/1.0.0-beta-016/fable/Divider.fs
C:/Users/egger/.nuget/packages/fulma.extensions/1.0.0-beta-016/fable/Divider.fs(46,39): (46,74) warning FSHARP: This upcast is unnecessary - the types are identical