### PR TITLE
The Divider emits a compile time warning when building the Fulma docs or consuming/using the Fulma divider in a project

### DIFF
--- a/src/Fulma.Extensions/Divider.fs
+++ b/src/Fulma.Extensions/Divider.fs
@@ -1,4 +1,5 @@
 namespace Fulma.Extensions
+#nowarn "66" // this upcast is unnecessary - the types are identical
 
 open Fulma
 open Fable.Helpers.React


### PR DESCRIPTION
When building the Fulma docs, I get the following compile time warning.

WARNING in ../src/Fulma.Extensions/Divider.fs
C:/Workspaces/GitHub/talbottmike/Fulma/src/Fulma.Extensions/Divider.fs(51,39): (51,74) warning FSHARP: This upcast is unnecessary - the types are identical
 @ ./src/FulmaExtensions/Divider.fs 5:0-75
 @ ./src/FulmaExtensions/Router.fs
 @ ./src/App.fs
 @ ./docs.fsproj
 @ multi ../node_modules/webpack-dev-server/client?http://localhost:8080 webpack/hot/dev-server babel-polyfill ./docs.fsproj

I don't see a problem with the line that is being referenced. (note the cast on line 46)
https://github.com/MangelMaxime/Fulma/blob/bbdb8b601049110fc613e963fb0a587c0da01289/src/Fulma.Extensions/Divider.fs#L45-L47

This warning occurs both when building the documentation and when using the Fulma Divider in my project.

This is the line being called in the fable-react project.

https://github.com/fable-compiler/fable-react/blob/c49681f5b75cee0b39b3ac15912627a6bf2005bb/src/Fable.React/Fable.Helpers.React.fs#L731-L732

I would expect the return type from the Fable function to be IHTMLProp but in practice it is HTMLAttr. Fulma will not compile without the cast.

This pull request just mutes the warning. If there is a better way to address this and I can help, please just let me know. Thanks
